### PR TITLE
ietf-tls-oldversions-deprecate normative

### DIFF
--- a/draft-ietf-emu-eap-tls13.xml
+++ b/draft-ietf-emu-eap-tls13.xml
@@ -686,6 +686,7 @@ Session-Id = Type-Code || Method-Id
 	<?rfc include='reference.RFC.8126'?>
 	<?rfc include='reference.RFC.8174'?>
 	<?rfc include='reference.RFC.8446'?>
+	<?rfc include='reference.I-D.ietf-tls-oldversions-deprecate'?>	
 </references>
 
 <references title='Informative references'>
@@ -766,7 +767,6 @@ Session-Id = Type-Code || Method-Id
 	<?rfc include='reference.RFC.7457'?>
 	<?rfc include='reference.RFC.7525'?>
 	<?rfc include='reference.RFC.8447'?>
-	<?rfc include='reference.I-D.ietf-tls-oldversions-deprecate'?>	
 	<?rfc include='reference.I-D.ietf-tls-md5-sha1-deprecate'?>
 	<?rfc include='reference.I-D.ietf-emu-eaptlscert'?>	
 	<?rfc include='reference.I-D.ietf-tls-ticketrequests'?>	


### PR DESCRIPTION
Éric Vyncke's commented that ietf-tls-oldversions-deprecate should be normative. The only reason it was informative was that EAP-TLS 1.3 did not want or needed to wait for ietf-tls-oldversions-deprecate to be published. No that ietf-tls-oldversions-deprecate is ahead in the publication que, there is no reason to have it informal anymore.