### PR TITLE
Message flows are example message flows.

### DIFF
--- a/draft-ietf-emu-eap-tls13.xml
+++ b/draft-ietf-emu-eap-tls13.xml
@@ -61,7 +61,7 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
 
 	<t>EAP-TLS <xref target="RFC5216"/> references TLS 1.0 <xref target="RFC2246"/> and TLS 1.1 <xref target="RFC4346"/>, but can also work with TLS 1.2 <xref target="RFC5246"/>. TLS 1.0 and 1.1 are formally deprecated and prohibited to negotiate and use <xref target="I-D.ietf-tls-oldversions-deprecate"/>. Weaknesses found in TLS 1.2, as well as new requirements for security, privacy, and reduced latency has led to the specification of TLS 1.3 <xref target="RFC8446"/>, which obsoletes TLS 1.2 <xref target="RFC5246"/>. TLS 1.3 is in large parts a complete remodeling of the TLS handshake protocol including a different message flow, different handshake messages, different key schedule, different cipher suites, different resumption, different privacy protection, and record padding. This means that significant parts of the normative text in the previous EAP-TLS specification <xref target="RFC5216"/> are not applicable to EAP-TLS with TLS 1.3 (or higher). Therefore, aspects such as resumption, privacy handling, and key derivation need to be appropriately addressed for EAP-TLS with TLS 1.3 (or higher).</t>
 
-	<t>This document defines how to use EAP-TLS with TLS 1.3 (or higher) and does not change how EAP-TLS is used with older versions of TLS. It does however provide additional guidance on authorization and resumption for EAP-TLS in general (regardless of the underlying TLS version used). While this document updates EAP-TLS <xref target="RFC5216"/>, it remains backwards compatible with it and existing implementations of EAP-TLS. This document only describes differences compared to <xref target="RFC5216"/>. All message flow are specific to TLS 1.3 and do not apply to TLS 1.2.</t>
+	<t>This document defines how to use EAP-TLS with TLS 1.3 (or higher) and does not change how EAP-TLS is used with older versions of TLS. It does however provide additional guidance on authorization and resumption for EAP-TLS in general (regardless of the underlying TLS version used). While this document updates EAP-TLS <xref target="RFC5216"/>, it remains backwards compatible with it and existing implementations of EAP-TLS. This document only describes differences compared to <xref target="RFC5216"/>. All message flow are example message flows specific to TLS 1.3 and do not apply to TLS 1.2.</t>
 
 	<t>In addition to the improved security and privacy offered by TLS 1.3, there are other significant benefits of using EAP-TLS with TLS 1.3. Privacy, which in EAP-TLS means that the peer username is not disclosed, is mandatory and achieved without any additional round-trips. Revocation checking is mandatory and simplified with OCSP stapling, and TLS 1.3 introduces more possibilities to reduce fragmentation when compared to earlier versions of TLS.</t>
 
@@ -88,7 +88,7 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
 
 			<t>The EAP-TLS server MUST authenticate with a certificate and SHOULD require the EAP-TLS peer to authenticate with a certificate. Certificates can be of any type supported by TLS including raw public keys. Pre-Shared Key (PSK) authentication SHALL NOT be used except for resumption. The full handshake in EAP-TLS with TLS 1.3 always provide forward secrecy by exchange of ephemeral "key_share" extentions in the ClientHello and ServerHello (e.g. containing ephemeral ECDHE public keys). SessionID is deprecated in TLS 1.3, see Sections 4.1.2 and 4.1.3 of <xref target="RFC8446"/>. TLS 1.3 introduced early application data which like all other application data is not used in EAP-TLS, see Section 4.2.10 of <xref target="RFC8446"/> for additional information of the "early_data" extension. Resumption is handled as described in <xref target="resumption"/>. TLS 1.3 introduced the Post-Handshake KeyUpdate message which is not useful and not expected in EAP-TLS. The EAP-TLS server always commits to not send any more handshake messages by sending a TLS close_notify alert. After the EAP-TLS server has received an empty EAP-Response to the EAP-Request containing the TLS close_notify alert, the EAP-TLS server sends EAP-Success.</t>
 			
-			<t>In the case where EAP-TLS with mutual authentication is successful (and neither HelloRetryRequest nor Post-Handshake messages are sent) the conversation will appear as shown in <xref target="figbase1"/>. </t>
+			<t><xref target="figbase1"/> shows an example message flow for a succesfull EAP-TLS full handshake with mutual authentication (and neither HelloRetryRequest nor Post-Handshake messages are sent).</t>
 
 <figure anchor="figbase1" title="EAP-TLS mutual authentication" align="center"><artwork><![CDATA[
  EAP-TLS Peer                                      EAP-TLS Server
@@ -130,7 +130,7 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
 
 			<t>To enable resumption when using EAP-TLS with TLS 1.3, the EAP-TLS server MUST send one or more NewSessionTicket messages (each containing a PSK, a PSK identity, a ticket lifetime, and other parameters) in the initial authentication. Note that TLS 1.3 <xref target="RFC8446"/> limits the ticket lifetime to a maximum of 604800 seconds (7 days) and EAP-TLS servers MUST respect this upper limit when issuing tickets. The NewSessionTicket is sent after the EAP-TLS server has received the client Finished message in the initial authentication. The PSK associated with the ticket depends on the client Finished and cannot be pre-computed in handshakes with client authentication. The NewSessionTicket message MUST NOT include an "early_data" extension. A mechanism by which clients can specify the desired number of tickets needed for future connections is defined in <xref target="I-D.ietf-tls-ticketrequests"/>.</t>
 
-			<t>In the case where EAP-TLS with mutual authentication and ticket establishment with two tickets is successful, the conversation will appear as shown in <xref target="figbase2"/>.</t>
+	<t><xref target="figbase2"/> shows an example message flow for a succesfull EAP-TLS full handshake with mutual authentication and ticket establishment of a single ticket.</t>
 
 <figure anchor="figbase2" title="EAP-TLS ticket establishment" align="center"><artwork><![CDATA[
  EAP-TLS Peer                                      EAP-TLS Server
@@ -177,9 +177,9 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
 			<t>For TLS 1.3, resumption is described in Section 2.2 of <xref target="RFC8446"/>. If the client has received a NewSessionTicket message from the EAP-TLS server, the client can use the PSK identity received in the ticket to negotiate the use of the associated PSK. If the EAP-TLS server accepts it, then the security context of the new connection is tied to the original connection and the key derived from the initial handshake is used to bootstrap the cryptographic state instead of a full handshake. It is up to the EAP-TLS peer whether to offer resumption, ut it is RECOMMENDED that the EAP-TLS peer offer resumption if it has a valid ticket that has not been used before. It is left to the EAP-TLS server whether to accept resumption, but it is RECOMMENDED that the EAP-TLS server accept resumption if the ticket that it issued is still valid. However, the EAP-TLS server MAY choose to require a full handshake. As in a full handshake, sending a NewSessionTicket is optional. As described in Appendix C.4 of <xref target="RFC8446"/>, reuse of a ticket allows passive observers to correlate different connections. EAP-TLS peers and EAP-TLS servers SHOULD follow the client tracking preventions in Appendix C.4 of <xref target="RFC8446"/>.</t>
 
 			<t>It is RECOMMENDED to use a Network Access Identifiers (NAIs) with the same realm in the resumption and the original full handshake. This requirement allows EAP packets to be routable to the same destination as the original full handshake. If this recommendation is not followed, resumption is likely to be impossible. When NAI reuse can be done without privacy implications, it is RECOMMENDED to use the same anonymous NAI in the resumption, as was used in the original full handshake <xref target="RFC7542"/>. For example, the NAI @realm can safely be reused since it does not provide any specific information to associate a user's resumption attempt with the original full handshake. However, reusing the NAI P2ZIM2F+OEVAO21nNWg2bVpgNnU=@realm enables an on-path attacker to associate a resumption attempt with the original full handshake. The TLS PSK identity is typically derived by the TLS implementation and may be an opaque blob without a routable realm. The TLS PSK identity is therefore in general unsuitable for deriving a NAI to use in the Identity Response.</t>
-			
-			<t>A subsequent successful resumption handshake where both sides authenticate via a PSK provisioned via an earlier NewSessionTicket and where the server provisions a single new ticket is shown in <xref target="figresumption"/>.</t>
-							
+
+			<t><xref target="figresumption"/> shows an example message flow for a subsequent succesfull EAP-TLS resumption handshake where both sides authenticate via a PSK provisioned via an earlier NewSessionTicket and where the server provisions a single new ticket.</t>
+										
 <figure anchor="figresumption" title="EAP-TLS resumption" align="center"><artwork><![CDATA[
  EAP-TLS Peer                                      EAP-TLS Server
 
@@ -197,39 +197,8 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
                                                  EAP-Type=EAP-TLS
                                                  (TLS ServerHello,
                                           TLS EncryptedExtensions,
-                              <--------              TLS Finished)
- EAP-Response/
- EAP-Type=EAP-TLS
-(TLS Finished)                -------->
-                                                      EAP-Request/
-                                                 EAP-Type=EAP-TLS
-                                            (TLS NewSessionTicket,
-                              <--------          TLS close_notify)
- EAP-Response/
- EAP-Type=EAP-TLS             -------->
-                              <--------               EAP-Success
-]]></artwork></figure>
-
-						<t>A subsequent successful resumption handshake where both sides authenticate via a PSK provisioned via an earlier NewSessionTicket and where the server does not provision any new tickets is shown in <xref target="figresumption2"/>.</t>
-							
-<figure anchor="figresumption2" title="EAP-TLS resumption" align="center"><artwork><![CDATA[
- EAP-TLS Peer                                      EAP-TLS Server
-
-                                                      EAP-Request/
-                              <--------                  Identity
- EAP-Response/
- Identity (Privacy-Friendly)  -------->
-                                                      EAP-Request/
-                                                 EAP-Type=EAP-TLS
-                              <--------                (TLS Start)
- EAP-Response/
- EAP-Type=EAP-TLS
-(TLS ClientHello)             -------->
-                                                      EAP-Request/
-                                                 EAP-Type=EAP-TLS
-                                                 (TLS ServerHello,
-                                          TLS EncryptedExtensions,
-                              <--------              TLS Finished)
+                              <--------              TLS Finished,
+                                             TLS NewSessionTicket)
  EAP-Response/
  EAP-Type=EAP-TLS
 (TLS Finished)                -------->
@@ -240,7 +209,6 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
  EAP-Type=EAP-TLS             -------->
                               <--------               EAP-Success
 ]]></artwork></figure>
-
 
 			<t>As specified in Section 2.2 of <xref target="RFC8446"/>, the EAP-TLS peer SHOULD supply a "key_share" extension when attempting resumption, which allows the EAP-TLS server to potentially decline resumption and fall back to a full handshake. If the EAP-TLS peer did not supply a "key_share" extension when attempting resumption, the EAP-TLS server needs to send HelloRetryRequest to signal that additional information is needed to complete the handshake, and the EAP-TLS peer needs to send a second ClientHello containing that information. Providing a "key_share" and using the "psk_dhe_ke" pre-shared key exchange mode is also important in order to limit the impact of a key compromise. When using "psk_dhe_ke", TLS 1.3 provides forward secrecy meaning that key leakage does not compromise any earlier connections. It is RECOMMMENDED to use "psk_dhe_ke" for resumption.</t>
 
@@ -262,7 +230,7 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
 				
 In earlier versions of TLS, error alerts could be warnings or fatal. In TLS 1.3, error alerts are always fatal and the only alerts sent at warning level are "close_notify" and "user_cancelled", both of which indicate that the connection is not going to continue normally, see <xref target="RFC8446"/>. </t>
 			
-			<t>In the case where the EAP-TLS server rejects the ClientHello with a fatal error, the conversation will appear as shown in <xref target="figterm1"/>. The EAP-TLS server can also partly reject the ClientHello with a HelloRetryRequest, see <xref target="helloretry"/>.</t>
+		<t><xref target="figterm1"/> shows an example message flow where the EAP-TLS server rejects the ClientHello with a Error alert. The EAP-TLS server can also partly reject the ClientHello with a HelloRetryRequest, see <xref target="helloretry"/>.</t>	
 
 <figure anchor="figterm1" title="EAP-TLS server rejection of ClientHello" align="center"><artwork><![CDATA[
  EAP-TLS Peer                                      EAP-TLS Server
@@ -285,9 +253,7 @@ In earlier versions of TLS, error alerts could be warnings or fatal. In TLS 1.3,
                               <--------               EAP-Failure
 ]]></artwork></figure>
 
-			<t>
-			In the case where EAP-TLS server authentication is unsuccessful, the conversation will appear as shown in <xref target="figterm2"/>.
-			</t>
+		<t><xref target="figterm2"/> shows an example message flow where EAP-TLS server authentication is unsuccessful and the EAP-TLS peer sends a TLS Error alert.</t>	
 
 <figure anchor="figterm2" title="EAP-TLS unsuccessful EAP-TLS server authentication" align="center"><artwork><![CDATA[
  EAP-TLS Peer                                      EAP-TLS Server
@@ -317,8 +283,8 @@ In earlier versions of TLS, error alerts could be warnings or fatal. In TLS 1.3,
                               <--------               EAP-Failure
 ]]></artwork></figure>
 
-			<t>In the case where the EAP-TLS server authenticates to the EAP-TLS peer successfully, but the EAP-TLS peer fails to authenticate to the EAP-TLS server, the conversation will appear as shown in <xref target="figterm3"/>.</t>
-
+	<t><xref target="figterm3"/> shows an example message flow where the EAP-TLS server authenticates to the EAP-TLS peer successfully, but the EAP-TLS peer fails to authenticate to the EAP-TLS server and sends a TLS Error alert.</t>
+			
 <figure anchor="figterm3" title="EAP-TLS unsuccessful client authentication" align="center"><artwork><![CDATA[
  EAP-TLS Peer                                      EAP-TLS Server
 
@@ -359,7 +325,7 @@ In earlier versions of TLS, error alerts could be warnings or fatal. In TLS 1.3,
 		<section title='No Peer Authentication'>
 			<t>This is a new section when compared to <xref target="RFC5216"/>.</t>
 
-			<t>In the case where EAP-TLS is used without peer authentication (e.g., emergency services, as described in <xref target="RFC7406"/>) the conversation will appear as shown in <xref target="figbase3"/>.</t>
+	<t><xref target="figbase3"/> shows an example message flow for a succesfull EAP-TLS full handshake without peer authentication (e.g., emergency services, as described in <xref target="RFC7406"/>).</t>			
 
 <figure anchor="figbase3" title="EAP-TLS without peer authentication" align="center"><artwork><![CDATA[
  EAP-TLS Peer                                      EAP-TLS Server
@@ -398,7 +364,7 @@ In earlier versions of TLS, error alerts could be warnings or fatal. In TLS 1.3,
 
 			<t>As defined in TLS 1.3 <xref target="RFC8446"/>, EAP-TLS servers can send a HelloRetryRequest message in response to a ClientHello if the EAP-TLS server finds an acceptable set of parameters but the initial ClientHello does not contain all the needed information to continue the handshake. One use case is if the EAP-TLS server does not support the groups in the "key_share" extension (or there is no "key_share" extension), but supports one of the groups in the "supported_groups" extension. In this case the client should send a new ClientHello with a "key_share" that the EAP-TLS server supports.</t>
 
-			<t>The case of a successful EAP-TLS mutual authentication after the EAP-TLS server has sent a HelloRetryRequest message is shown in <xref target="fighelloretryrequest"/>. Note the extra round-trip as a result of the HelloRetryRequest.</t>
+			<t><xref target="fighelloretryrequest"/> shows an example message flow for a succesfull EAP-TLS full handshake with mutual authentication and HelloRetryRequest. Note the extra round-trip as a result of the HelloRetryRequest.</t>
 
 <figure anchor="fighelloretryrequest" title="EAP-TLS with Hello Retry Request" align="center"><artwork><![CDATA[
  EAP-TLS Peer                                      EAP-TLS Server


### PR DESCRIPTION
Some of the text describing the figures indicated that TLS 1.3 only has one possible message flow. This pull request change the text to make it is clear that the message flows are examples.

Based on discussion on the List initiated by Alan.