### PR TITLE
Going back to -12 Type-Code in context

### DIFF
--- a/draft-ietf-emu-eap-tls13.xml
+++ b/draft-ietf-emu-eap-tls13.xml
@@ -488,12 +488,12 @@ In earlier versions of TLS, error alerts could be warnings or fatal. In TLS 1.3,
 
 <figure><artwork><![CDATA[
 Type-Code  = 0x0D
-MSK        = TLS-Exporter("EXPORTER_EAP_TLS_MSK_"+Type-Code,"",64)
-EMSK       = TLS-Exporter("EXPORTER_EAP_TLS_EMSK_"+Type-Code,"",64)
-Method-Id  = TLS-Exporter("EXPORTER_EAP_TLS_Method-Id_"+Type-Code,"",64)
+MSK        = TLS-Exporter("EXPORTER_EAP_TLS_MSK", Type-Code, 64)
+EMSK       = TLS-Exporter("EXPORTER_EAP_TLS_EMSK", Type-Code, 64)
+Method-Id  = TLS-Exporter("EXPORTER_EAP_TLS_Method-Id", Type-Code, 64)
 Session-Id = Type-Code || Method-Id
 ]]></artwork></figure>
-		<t>A zero-length context (indicated by "") is used in the TLS exporter interface. The EAP-TLS Type-Code of '0D' (in hexadecimal) is appended to the label strings. Other TLS based EAP methods can use exporters in a similar fashion by replacing the EAP-TLS Type-Code with their own Type-Code (encoded as a hexadecimal string).</t>
+		<t>Other TLS based EAP methods can use exporters in a similar fashion by replacing the EAP-TLS Type-Code with their own Type-Code (encoded as a hexadecimal string).</t>
 
 		<t><xref target="RFC5247"/> deprecates the use of IV. Thus, RECV-IV and SEND-IV are not exported in EAP-TLS with TLS 1.3. As noted in <xref target="RFC5247"/>, lower layers use the MSK in a lower-layer dependent manner. EAP-TLS with TLS 1.3 exports the MSK and does not specify how it used by lower layers.</t>
 
@@ -541,17 +541,17 @@ Session-Id = Type-Code || Method-Id
             <ttcol align="left">DTLS-OK</ttcol>
             <ttcol align="left">Recommended</ttcol>
             <ttcol align="left">Note</ttcol>
-            <c>EXPORTER_EAP_TLS_MSK_</c>
+            <c>EXPORTER_EAP_TLS_MSK</c>
             <c>N</c>
             <c>Y</c>
             <c></c>
             <c></c><c></c><c></c><c></c>
-	    	<c>EXPORTER_EAP_TLS_EMSK_</c>
+	    	<c>EXPORTER_EAP_TLS_EMSK</c>
             <c>N</c>
             <c>Y</c>
             <c></c>
             <c></c><c></c><c></c><c></c>
-            <c>EXPORTER_EAP_TLS_Method-Id_</c>
+            <c>EXPORTER_EAP_TLS_Method-Id</c>
             <c>N</c>
             <c>Y</c>
             <c></c>


### PR DESCRIPTION
Appending things to labels are not agreeing with the IANA registry for labels. Registering labels for each TLS based EAP type would explode the registry.