### PR TITLE
Protected success indication application data 0x00

### DIFF
--- a/draft-ietf-emu-eap-tls13.xml
+++ b/draft-ietf-emu-eap-tls13.xml
@@ -86,7 +86,7 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
 		<section title='Mutual Authentication'>
 			<t>This section updates Section 2.1.1 of <xref target="RFC5216"/>.</t>
 
-			<t>The EAP-TLS server MUST authenticate with a certificate and SHOULD require the EAP-TLS peer to authenticate with a certificate. Certificates can be of any type supported by TLS including raw public keys. Pre-Shared Key (PSK) authentication SHALL NOT be used except for resumption. The full handshake in EAP-TLS with TLS 1.3 always provide forward secrecy by exchange of ephemeral "key_share" extentions in the ClientHello and ServerHello (e.g. containing ephemeral ECDHE public keys). SessionID is deprecated in TLS 1.3, see Sections 4.1.2 and 4.1.3 of <xref target="RFC8446"/>. TLS 1.3 introduced early application data which like all other application data is not used in EAP-TLS, see Section 4.2.10 of <xref target="RFC8446"/> for additional information of the "early_data" extension. Resumption is handled as described in <xref target="resumption"/>. TLS 1.3 introduced the Post-Handshake KeyUpdate message which is not useful and not expected in EAP-TLS. The EAP-TLS server always commits to not send any more handshake messages by sending a TLS close_notify alert. After the EAP-TLS server has received an empty EAP-Response to the EAP-Request containing the TLS close_notify alert, the EAP-TLS server sends EAP-Success.</t>
+			<t>The EAP-TLS server MUST authenticate with a certificate and SHOULD require the EAP-TLS peer to authenticate with a certificate. Certificates can be of any type supported by TLS including raw public keys. Pre-Shared Key (PSK) authentication SHALL NOT be used except for resumption. The full handshake in EAP-TLS with TLS 1.3 always provide forward secrecy by exchange of ephemeral "key_share" extentions in the ClientHello and ServerHello (e.g. containing ephemeral ECDHE public keys). SessionID is deprecated in TLS 1.3, see Sections 4.1.2 and 4.1.3 of <xref target="RFC8446"/>. TLS 1.3 introduced early application data which like all other application data is not used in EAP-TLS, see Section 4.2.10 of <xref target="RFC8446"/> for additional information of the "early_data" extension. Resumption is handled as described in <xref target="resumption"/>. TLS 1.3 introduced the Post-Handshake KeyUpdate message which is not useful and not expected in EAP-TLS. As a protected success indication <xref target="RFC3748"/> the EAP-TLS server always sends TLS application data 0x00, see Section 2.5. Note that a TLS implementation MAY not allow the EAP-TLS layer to control in which order things are sent and the application data MAY therefore be sent before a NewSessionTicket. TLS application data 0x00 is therefore to be interpretated as success after the EAP-Request that contains TLS application data 0x00. After the EAP-TLS server has received an empty EAP-Response to the EAP-Request containing the TLS application data 0x00, the EAP-TLS server sends EAP-Success.</t>
 			
 			<t>In the case where EAP-TLS with mutual authentication is successful (and neither HelloRetryRequest nor Post-Handshake messages are sent) the conversation will appear as shown in <xref target="figbase1"/>. </t>
 
@@ -118,7 +118,7 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
  TLS Finished)                -------->
                                                       EAP-Request/
                                                  EAP-Type=EAP-TLS
-                              <--------         (TLS close_notify)
+                              <-------- TLS Application Data 0x00)
  EAP-Response/
  EAP-Type=EAP-TLS             -------->
                               <--------               EAP-Success
@@ -162,7 +162,7 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
                                                  EAP-Type=EAP-TLS
                                             (TLS NewSessionTicket,
                                              TLS NewSessionTicket,
-                              <--------          TLS close_notify)
+                              <-------- TLS Application Data 0x00)
  EAP-Response/
  EAP-Type=EAP-TLS             -------->
                               <--------               EAP-Success
@@ -204,7 +204,7 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
                                                       EAP-Request/
                                                  EAP-Type=EAP-TLS
                                             (TLS NewSessionTicket,
-                              <--------          TLS close_notify)
+                              <-------- TLS Application Data 0x00)
  EAP-Response/
  EAP-Type=EAP-TLS             -------->
                               <--------               EAP-Success
@@ -235,7 +235,7 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
 (TLS Finished)                -------->
                                                       EAP-Request/
                                                  EAP-Type=EAP-TLS
-                              <--------         (TLS close_notify)
+                              <-------- TLS Application Data 0x00)
  EAP-Response/
  EAP-Type=EAP-TLS             -------->
                               <--------               EAP-Success
@@ -258,7 +258,6 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
 			</t>
 			
 			<t>Figures <xref target="figterm1" format="counter"/>, <xref target="figterm2" format="counter"/>, and <xref target="figterm3" format="counter"/> illustrate message flows in several cases where the EAP-TLS peer or EAP-TLS server sends a TLS fatal alert message.
-				
 				
 In earlier versions of TLS, error alerts could be warnings or fatal. In TLS 1.3, error alerts are always fatal and the only alerts sent at warning level are "close_notify" and "user_cancelled", both of which indicate that the connection is not going to continue normally, see <xref target="RFC8446"/>. </t>
 			
@@ -386,7 +385,7 @@ In earlier versions of TLS, error alerts could be warnings or fatal. In TLS 1.3,
 (TLS Finished)                -------->
                                                       EAP-Request/
                                                  EAP-Type=EAP-TLS
-                              <--------         (TLS close_notify)
+                              <-------- TLS Application Data 0x00)
  EAP-Response/
  EAP-Type=EAP-TLS             -------->
                               <--------               EAP-Success
@@ -435,7 +434,7 @@ In earlier versions of TLS, error alerts could be warnings or fatal. In TLS 1.3,
  TLS Finished)                -------->
                                                       EAP-Request/
                                                  EAP-Type=EAP-TLS
-                              <--------         (TLS close_notify)
+                              <-------- TLS Application Data 0x00)
  EAP-Response/
  EAP-Type=EAP-TLS             -------->
                               <--------               EAP-Success


### PR DESCRIPTION
This was discussed and EMU WG IETF 110.

https://datatracker.ietf.org/meeting/110/materials/slides-110-emu-eap-tls-13-implementation-report-00
https://datatracker.ietf.org/meeting/110/materials/slides-110-emu-eap-tls-with-tls-13-00

Interop test was done by several implementors during the hackaton. The conclusions was the application data works well as a protected success indication and that close_notify is problematic. Alan DeKok stated that application data will not cause problems for other TLS based EAP methods. The consensus in the WG was to use application data 0x00 as a protected success indication on the EAP-TLS layer.

The application data is not controlling the TLS layer. After sending application data (or any other success indication) the EAP-TLS can only send EAP-SUCCESS.

The working group argued that the IESG and TLS WG resistance against use application data was as it was used in -13 when it promised that no more handshake messages was sent by the TLS layers. The EMU WG hopes and thinks that the IESG and the TLS WG will be ok with the current use of applicaiton data as a protected success indication on the EAP-TLS layer. 

Additional changes related to this (protected success and protected failure) will/is done in the EAP State Machnine PR.