### PR TITLE
"EAP-TLS 1.3" name

### DIFF
--- a/draft-ietf-emu-eap-tls13.xml
+++ b/draft-ietf-emu-eap-tls13.xml
@@ -12,8 +12,8 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
 
 <front>
 
-	<title abbrev="EAP-TLS with TLS 1.3">
-	Using EAP-TLS with TLS 1.3
+	<title abbrev="EAP-TLS 1.3">
+	Using EAP-TLS with TLS 1.3 (EAP-TLS 1.3)
 	</title>
 
 	<author initials="J." surname="Mattsson" fullname="John Preuß Mattsson">
@@ -48,7 +48,7 @@ href='http://xml.resource.org/authoring/rfc2629.xslt' ?>
 
 <abstract>
 	<t>
-	The Extensible Authentication Protocol (EAP), defined in RFC 3748, provides a standard mechanism for support of multiple authentication methods. This document specifies the use of EAP-Transport Layer Security (EAP-TLS) with TLS 1.3 while remaining backwards compatible with existing implementations of EAP-TLS. TLS 1.3 provides significantly improved security, privacy, and reduced latency when compared to earlier versions of TLS. EAP-TLS with TLS 1.3 further improves security and privacy by always providing forward secrecy, never disclosing the peer identity, and by mandating use of revocation checking. This document also provides guidance on authorization and resumption for EAP-TLS in general (regardless of the underlying TLS version used). This document updates RFC 5216.
+	The Extensible Authentication Protocol (EAP), defined in RFC 3748, provides a standard mechanism for support of multiple authentication methods. This document specifies the use of EAP-Transport Layer Security (EAP-TLS) with TLS 1.3 while remaining backwards compatible with existing implementations of EAP-TLS. TLS 1.3 provides significantly improved security, privacy, and reduced latency when compared to earlier versions of TLS. EAP-TLS with TLS 1.3 (EAP-TLS 1.3) further improves security and privacy by always providing forward secrecy, never disclosing the peer identity, and by mandating use of revocation checking. This document also provides guidance on authorization and resumption for EAP-TLS in general (regardless of the underlying TLS version used). This document updates RFC 5216.
 	</t>
 </abstract>
 


### PR DESCRIPTION
I see that "EAP-TLS 1.3" is used more an more in the discussions to refer to this the combination of EAP-TLS and TLS 1.3. The term is used in the document but not in the title and abstract